### PR TITLE
chore(repo): add oxlint and oxfmt as linting and formatting tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,28 @@ jobs:
             exit 1
           fi
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run fmt:check
+
   lint-commits:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "printWidth": 120,
+  "endOfLine": "lf",
+  "trailingComma": "es5",
+  "ignorePatterns": ["dist/**"]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript"],
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "typescript/no-unused-vars": "error",
+    "typescript/no-explicit-any": "warn"
+  },
+  "ignorePatterns": ["dist/**", "node_modules/**"],
+  "options": {
+    "typeAware": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@types/node": "^25.5.0",
+        "oxfmt": "0.56.0",
+        "oxlint": "1.71.0",
+        "oxlint-tsgolint": "0.23.0",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2"
       },
@@ -444,6 +447,736 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.56.0.tgz",
+      "integrity": "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.56.0.tgz",
+      "integrity": "sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.56.0.tgz",
+      "integrity": "sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.56.0.tgz",
+      "integrity": "sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.56.0.tgz",
+      "integrity": "sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.56.0.tgz",
+      "integrity": "sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.56.0.tgz",
+      "integrity": "sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.56.0.tgz",
+      "integrity": "sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.56.0.tgz",
+      "integrity": "sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.56.0.tgz",
+      "integrity": "sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.56.0.tgz",
+      "integrity": "sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.56.0.tgz",
+      "integrity": "sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.56.0.tgz",
+      "integrity": "sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.56.0.tgz",
+      "integrity": "sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.56.0.tgz",
+      "integrity": "sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.56.0.tgz",
+      "integrity": "sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.56.0.tgz",
+      "integrity": "sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.56.0.tgz",
+      "integrity": "sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.56.0.tgz",
+      "integrity": "sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint-tsgolint/darwin-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/darwin-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.71.0.tgz",
+      "integrity": "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.71.0.tgz",
+      "integrity": "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.71.0.tgz",
+      "integrity": "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.71.0.tgz",
+      "integrity": "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.71.0.tgz",
+      "integrity": "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.71.0.tgz",
+      "integrity": "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.71.0.tgz",
+      "integrity": "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.71.0.tgz",
+      "integrity": "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.71.0.tgz",
+      "integrity": "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.71.0.tgz",
+      "integrity": "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.71.0.tgz",
+      "integrity": "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.71.0.tgz",
+      "integrity": "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.71.0.tgz",
+      "integrity": "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.71.0.tgz",
+      "integrity": "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.71.0.tgz",
+      "integrity": "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.71.0.tgz",
+      "integrity": "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.71.0.tgz",
+      "integrity": "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.71.0.tgz",
+      "integrity": "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.71.0.tgz",
+      "integrity": "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@simple-libs/child-process-utils": {
@@ -1894,6 +2627,125 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.56.0.tgz",
+      "integrity": "sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.56.0",
+        "@oxfmt/binding-android-arm64": "0.56.0",
+        "@oxfmt/binding-darwin-arm64": "0.56.0",
+        "@oxfmt/binding-darwin-x64": "0.56.0",
+        "@oxfmt/binding-freebsd-x64": "0.56.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.56.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.56.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.56.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.56.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.56.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-x64-musl": "0.56.0",
+        "@oxfmt/binding-openharmony-arm64": "0.56.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.56.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.56.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.56.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.71.0.tgz",
+      "integrity": "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.71.0",
+        "@oxlint/binding-android-arm64": "1.71.0",
+        "@oxlint/binding-darwin-arm64": "1.71.0",
+        "@oxlint/binding-darwin-x64": "1.71.0",
+        "@oxlint/binding-freebsd-x64": "1.71.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.71.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.71.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.71.0",
+        "@oxlint/binding-linux-arm64-musl": "1.71.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.71.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.71.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.71.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.71.0",
+        "@oxlint/binding-linux-x64-gnu": "1.71.0",
+        "@oxlint/binding-linux-x64-musl": "1.71.0",
+        "@oxlint/binding-openharmony-arm64": "1.71.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.71.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.71.0",
+        "@oxlint/binding-win32-x64-msvc": "1.71.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-tsgolint": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.23.0.tgz",
+      "integrity": "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsgolint": "bin/tsgolint.js"
+      },
+      "optionalDependencies": {
+        "@oxlint-tsgolint/darwin-arm64": "0.23.0",
+        "@oxlint-tsgolint/darwin-x64": "0.23.0",
+        "@oxlint-tsgolint/linux-arm64": "0.23.0",
+        "@oxlint-tsgolint/linux-x64": "0.23.0",
+        "@oxlint-tsgolint/win32-arm64": "0.23.0",
+        "@oxlint-tsgolint/win32-x64": "0.23.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2342,6 +3194,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "dev": "ts-node src/index.ts",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "lint": "oxlint src/",
+    "lint:fix": "oxlint src/ --fix",
+    "fmt": "oxfmt src/",
+    "fmt:check": "oxfmt src/ --check"
   },
   "keywords": [
     "fpl",
@@ -44,6 +48,9 @@
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@types/node": "^25.5.0",
+    "oxfmt": "0.56.0",
+    "oxlint": "1.71.0",
+    "oxlint-tsgolint": "0.23.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 /**
  * FPL MCP Server
- * 
+ *
  * This is the main entry point for the Fantasy Premier League MCP server.
  * It initializes the MCP server with SDK configuration and registers all available tools.
  */
@@ -67,7 +67,9 @@ class FPLMCPServer {
   private logServerInfo(): void {
     const nodeEnv = process.env.NODE_ENV || 'development';
     logger.info(`FPL MCP Server v1.0.0 initializing in ${nodeEnv} mode`);
-    logger.info('Registering 8 FPL tools: gameweek, player-stats, fixtures, compare-players, team-info, search-players, search-teams, manager-team');
+    logger.info(
+      'Registering 8 FPL tools: gameweek, player-stats, fixtures, compare-players, team-info, search-players, search-teams, manager-team'
+    );
   }
 
   /**
@@ -147,7 +149,7 @@ class FPLMCPServer {
     // Register get_manager_team tool
     this.server.tool(
       'get_manager_team',
-      'Get a manager\'s team selection for a specific gameweek, including starting XI, bench, captain, formation, and points. If gameweek is not specified, returns the current gameweek team.',
+      "Get a manager's team selection for a specific gameweek, including starting XI, bench, captain, formation, and points. If gameweek is not specified, returns the current gameweek team.",
       ManagerTeamInputSchema.shape,
       async (args, _extra) => {
         return await this.executeToolWithErrorHandling('get_manager_team', args, getManagerTeamTool);
@@ -162,27 +164,26 @@ class FPLMCPServer {
    */
   private async executeToolWithErrorHandling<T>(
     toolName: string,
-    args: any,
+    args: unknown,
     toolHandler: (args: T) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
   ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
     const startTime = Date.now();
-    
+
     try {
       logger.debug(`Executing tool: ${toolName}`, { args });
-      
-      const result = await toolHandler(args);
+
+      const result = await toolHandler(args as T);
       const duration = Date.now() - startTime;
-      
+
       logger.info(`Tool ${toolName} completed successfully`, { duration });
       return result;
-      
     } catch (error) {
       const duration = Date.now() - startTime;
       logger.error(`Tool ${toolName} failed`, { duration, error });
-      
+
       // Create standardized error response
       const errorResponse = ErrorHandler.handleUnexpectedError(error);
-      
+
       return {
         content: [
           {
@@ -254,10 +255,10 @@ class FPLMCPServer {
       logger.warn('Shutdown already in progress...');
       return;
     }
-    
+
     this.isShuttingDown = true;
     logger.info('FPL MCP Server shutting down...');
-    
+
     // Give a moment for any pending operations to complete
     setTimeout(() => {
       logger.info('Shutdown complete');

--- a/src/tools/compare-players.ts
+++ b/src/tools/compare-players.ts
@@ -1,6 +1,6 @@
 /**
  * Player comparison tool
- * 
+ *
  * This tool retrieves and compares statistics for multiple players,
  * returning comparative data in a structured format for analysis.
  */
@@ -27,7 +27,9 @@ interface PlayerComparison {
 /**
  * Compare players tool handler
  */
-export async function comparePlayersTool(args: ComparePlayersInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function comparePlayersTool(
+  args: ComparePlayersInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = ComparePlayersInputSchema.safeParse(args);
   if (!validationResult.success) {
@@ -50,10 +52,10 @@ export async function comparePlayersTool(args: ComparePlayersInput): Promise<{ c
   const result = await safeExecute(async (): Promise<PlayerComparison> => {
     // Initialize FPL client
     const fpl = new FPL();
-    
+
     // Get bootstrap data which includes all players, teams, and element types
     const bootstrapData = await fpl.getBootstrapData();
-    
+
     if (!bootstrapData || !bootstrapData.elements || !bootstrapData.teams || !bootstrapData.element_types) {
       throw new Error('No player data available from FPL API');
     }
@@ -61,28 +63,28 @@ export async function comparePlayersTool(args: ComparePlayersInput): Promise<{ c
     const elements = bootstrapData.elements;
     const teams = bootstrapData.teams;
     const elementTypes = bootstrapData.element_types;
-    
+
     const validPlayers: PlayerStats[] = [];
     const invalidPlayerIds: number[] = [];
-    
+
     // Process each player ID
     for (const playerId of playerIds) {
       // Find the player by ID
       const player = elements.find((element) => element.id === playerId);
-      
+
       if (!player) {
         invalidPlayerIds.push(playerId);
         continue;
       }
-      
+
       // Find the player's team
       const team = teams.find((t) => t.id === player.team);
       const teamName = team ? team.name : 'Unknown Team';
-      
+
       // Find the player's position
       const elementType = elementTypes.find((et) => et.id === player.element_type);
       const position = elementType ? elementType.singular_name : 'Unknown Position';
-      
+
       // Transform the API response to match our PlayerStats interface
       const playerStats: PlayerStats = {
         id: player.id,
@@ -94,29 +96,27 @@ export async function comparePlayersTool(args: ComparePlayersInput): Promise<{ c
         assists: player.assists,
         cost: player.now_cost / 10, // FPL API returns cost in tenths of millions
         ownership: parseFloat(player.selected_by_percent),
-        form: player.form
+        form: player.form,
       };
-      
+
       validPlayers.push(playerStats);
     }
-    
+
     // If no valid players found, throw an error
     if (validPlayers.length === 0) {
-      throw new FPLError(
-        ErrorCode.PLAYER_NOT_FOUND,
-        'None of the provided player IDs were found.',
-        { invalidPlayerIds }
-      );
+      throw new FPLError(ErrorCode.PLAYER_NOT_FOUND, 'None of the provided player IDs were found.', {
+        invalidPlayerIds,
+      });
     }
-    
+
     return {
       validPlayers,
       invalidPlayerIds,
       comparison: {
         totalPlayers: playerIds.length,
         validPlayers: validPlayers.length,
-        invalidPlayers: invalidPlayerIds.length
-      }
+        invalidPlayers: invalidPlayerIds.length,
+      },
     };
   }, 'comparePlayersTool');
 
@@ -138,7 +138,7 @@ export async function comparePlayersTool(args: ComparePlayersInput): Promise<{ c
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/fixtures.ts
+++ b/src/tools/fixtures.ts
@@ -1,6 +1,6 @@
 /**
  * Gameweek fixtures tool
- * 
+ *
  * This tool retrieves all fixtures for a specific gameweek
  * including team names, kickoff times, and match results.
  */
@@ -13,58 +13,60 @@ import { safeExecute } from '../utils/error-handler.js';
 /**
  * Get gameweek fixtures tool handler
  */
-export async function getGameweekFixturesTool(args: GameweekFixturesInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function getGameweekFixturesTool(
+  args: GameweekFixturesInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   const result = await safeExecute(async (): Promise<Fixture[]> => {
     const { gameweek } = args;
-    
+
     // Initialize FPL client
     const fpl = new FPL();
-    
+
     // Get bootstrap data to access team information
     const bootstrapData = await fpl.getBootstrapData();
-    
+
     if (!bootstrapData || !bootstrapData.teams) {
       throw new Error('Unable to retrieve team data from FPL API');
     }
-    
+
     // Create team mapping for ID to name conversion
     const teams = bootstrapData.teams;
     const teamMap = new Map<number, string>();
-    teams.forEach(team => {
+    teams.forEach((team) => {
       teamMap.set(team.id, team.name);
     });
-    
+
     // Get fixtures for the specified gameweek
     const fixturesData = await fpl.getFixtures();
-    
+
     if (!fixturesData || !Array.isArray(fixturesData)) {
       throw new Error('Unable to retrieve fixtures data from FPL API');
     }
-    
+
     // Use the typed fixtures from fpl-fetch
     const allFixtures = fixturesData;
-    const gameweekFixtures = allFixtures.filter(fixture => fixture.event === gameweek);
-    
+    const gameweekFixtures = allFixtures.filter((fixture) => fixture.event === gameweek);
+
     // Check if gameweek has any fixtures
     if (gameweekFixtures.length === 0) {
       // Check if gameweek is valid (1-38)
       if (gameweek < 1 || gameweek > 38) {
         throw new Error(`Invalid gameweek number: ${gameweek}. Must be between 1 and 38.`);
       }
-      
+
       // Return empty array for valid gameweeks with no fixtures yet
       return [];
     }
-    
+
     // Transform fixtures to match our Fixture interface
-    const transformedFixtures: Fixture[] = gameweekFixtures.map(fixture => {
+    const transformedFixtures: Fixture[] = gameweekFixtures.map((fixture) => {
       const homeTeam = teamMap.get(fixture.team_h);
       const awayTeam = teamMap.get(fixture.team_a);
-      
+
       if (!homeTeam || !awayTeam) {
         throw new Error(`Unable to find team names for fixture ${fixture.id}`);
       }
-      
+
       return {
         id: fixture.id,
         gameweek: fixture.event,
@@ -73,10 +75,10 @@ export async function getGameweekFixturesTool(args: GameweekFixturesInput): Prom
         kickoffTime: fixture.kickoff_time || 'TBD',
         homeScore: fixture.team_h_score ?? undefined,
         awayScore: fixture.team_a_score ?? undefined,
-        finished: fixture.finished
+        finished: fixture.finished,
       };
     });
-    
+
     // Sort fixtures by kickoff time for better presentation
     transformedFixtures.sort((a, b) => {
       if (a.kickoffTime === 'TBD' && b.kickoffTime === 'TBD') return 0;
@@ -84,7 +86,7 @@ export async function getGameweekFixturesTool(args: GameweekFixturesInput): Prom
       if (b.kickoffTime === 'TBD') return -1;
       return new Date(a.kickoffTime).getTime() - new Date(b.kickoffTime).getTime();
     });
-    
+
     return transformedFixtures;
   }, 'getGameweekFixturesTool');
 
@@ -106,7 +108,7 @@ export async function getGameweekFixturesTool(args: GameweekFixturesInput): Prom
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/gameweek.ts
+++ b/src/tools/gameweek.ts
@@ -1,6 +1,6 @@
 /**
  * Current gameweek status tool
- * 
+ *
  * This tool retrieves the current gameweek information including
  * gameweek number, deadline, and completion status.
  */
@@ -9,55 +9,56 @@ import FPL from 'fpl-fetch';
 import { GameweekStatus } from '../types/fpl-types.js';
 import { safeExecute } from '../utils/error-handler.js';
 
-
 /**
  * Get current gameweek status tool handler
  */
-export async function getCurrentGameweekTool(_args: Record<string, never>): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function getCurrentGameweekTool(
+  _args: Record<string, never>
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   const result = await safeExecute(async (): Promise<GameweekStatus> => {
     // Initialize FPL client
     const fpl = new FPL();
-    
+
     // Get bootstrap data which includes gameweek events
     const bootstrapData = await fpl.getBootstrapData();
-    
+
     if (!bootstrapData || !bootstrapData.events || bootstrapData.events.length === 0) {
       throw new Error('No gameweek data available from FPL API');
     }
-    
+
     const events = bootstrapData.events;
-    
+
     // Find the current gameweek
     const currentGameweek = events.find((event) => event.is_current);
-    
+
     if (!currentGameweek) {
       // If no current gameweek, find the next one
       const nextGameweek = events.find((event) => event.is_next);
-      
+
       if (!nextGameweek) {
         throw new Error('Unable to determine current or next gameweek');
       }
-      
+
       // Return next gameweek as current if no current is active
       return {
         current: nextGameweek.id,
         deadline: nextGameweek.deadline_time,
         finished: false,
-        next: undefined
+        next: undefined,
       };
     }
-    
+
     // Find the next gameweek
     const nextGameweek = events.find((event) => event.is_next);
-    
+
     // Transform the API response to match our GameweekStatus interface
     const gameweekStatus: GameweekStatus = {
       current: currentGameweek.id,
       deadline: currentGameweek.deadline_time,
       finished: currentGameweek.finished,
-      next: nextGameweek ? nextGameweek.id : undefined
+      next: nextGameweek ? nextGameweek.id : undefined,
     };
-    
+
     return gameweekStatus;
   }, 'getCurrentGameweekTool');
 
@@ -79,7 +80,7 @@ export async function getCurrentGameweekTool(_args: Record<string, never>): Prom
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/manager-team.ts
+++ b/src/tools/manager-team.ts
@@ -1,6 +1,6 @@
 /**
  * Manager team tool
- * 
+ *
  * This tool retrieves a manager's team selection for a specific gameweek,
  * including starting XI, bench, captain choices, formation, and points.
  */
@@ -15,7 +15,9 @@ import { logger } from '../utils/logger.js';
 /**
  * Manager team tool handler
  */
-export async function getManagerTeamTool(args: ManagerTeamInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function getManagerTeamTool(
+  args: ManagerTeamInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = ManagerTeamInputSchema.safeParse(args);
   if (!validationResult.success) {
@@ -37,24 +39,22 @@ export async function getManagerTeamTool(args: ManagerTeamInput): Promise<{ cont
 
   const result = await safeExecute(async () => {
     const fpl = new FPL();
-    
+
     // Get manager summary to verify manager exists and get current gameweek if not specified
     const managerSummary = await fpl.getManager(managerId);
-    
+
     if (!managerSummary) {
-      return ErrorHandler.createErrorResponse(
-        ErrorCode.PLAYER_NOT_FOUND,
-        `Manager with ID ${managerId} not found.`,
-        { managerId }
-      );
+      return ErrorHandler.createErrorResponse(ErrorCode.PLAYER_NOT_FOUND, `Manager with ID ${managerId} not found.`, {
+        managerId,
+      });
     }
 
     // Use current gameweek if not specified
     const targetGameweek = gameweek || managerSummary.current_event;
-    
+
     // Get manager's picks for the specified gameweek
     const picks = await fpl.getManagerGameweekPicks(managerId, targetGameweek);
-    
+
     if (!picks || !picks.picks || picks.picks.length === 0) {
       return ErrorHandler.createErrorResponse(
         ErrorCode.NO_DATA_AVAILABLE,
@@ -65,13 +65,13 @@ export async function getManagerTeamTool(args: ManagerTeamInput): Promise<{ cont
 
     // Get bootstrap data to enrich player information
     const bootstrapData = await bootstrapCache.getBootstrapData();
-    
+
     // Build player details
     const playerDetails: ManagerTeamPlayer[] = picks.picks.map((pick) => {
       const player = bootstrapData.elements.find((p) => p.id === pick.element);
       const team = bootstrapData.teams.find((t) => t.id === player?.team);
       const position = bootstrapData.element_types.find((et) => et.id === pick.element_type);
-      
+
       return {
         id: pick.element,
         name: player?.web_name || 'Unknown',
@@ -88,11 +88,11 @@ export async function getManagerTeamTool(args: ManagerTeamInput): Promise<{ cont
     // Separate starting XI and bench (positions 1-11 are starting, 12-15 are bench)
     const startingXI = playerDetails.filter((p) => p.positionInTeam <= 11);
     const bench = playerDetails.filter((p) => p.positionInTeam > 11);
-    
+
     // Find captain and vice captain
     const captain = playerDetails.find((p) => p.isCaptain);
     const viceCaptain = playerDetails.find((p) => p.isViceCaptain);
-    
+
     if (!captain || !viceCaptain) {
       logger.warn('Captain or vice captain not found in picks', { managerId, gameweek: targetGameweek });
     }
@@ -139,7 +139,7 @@ export async function getManagerTeamTool(args: ManagerTeamInput): Promise<{ cont
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/player-stats.ts
+++ b/src/tools/player-stats.ts
@@ -1,6 +1,6 @@
 /**
  * Player statistics tool
- * 
+ *
  * This tool retrieves comprehensive statistics for a specific player
  * including points, goals, assists, cost, and ownership data.
  */
@@ -14,7 +14,9 @@ import { ErrorHandler, ErrorCode, FPLError } from '../utils/error-handler.js';
 /**
  * Get player statistics tool handler
  */
-export async function getPlayerStatsTool(args: PlayerStatsInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function getPlayerStatsTool(
+  args: PlayerStatsInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = PlayerStatsInputSchema.safeParse(args);
   if (!validationResult.success) {
@@ -37,10 +39,10 @@ export async function getPlayerStatsTool(args: PlayerStatsInput): Promise<{ cont
   const result = await safeExecute(async (): Promise<PlayerStats> => {
     // Initialize FPL client
     const fpl = new FPL();
-    
+
     // Get bootstrap data which includes all players, teams, and element types
     const bootstrapData = await fpl.getBootstrapData();
-    
+
     if (!bootstrapData || !bootstrapData.elements || !bootstrapData.teams || !bootstrapData.element_types) {
       throw new Error('No player data available from FPL API');
     }
@@ -48,26 +50,22 @@ export async function getPlayerStatsTool(args: PlayerStatsInput): Promise<{ cont
     const elements = bootstrapData.elements;
     const teams = bootstrapData.teams;
     const elementTypes = bootstrapData.element_types;
-    
+
     // Find the player by ID
     const player = elements.find((element) => element.id === playerId);
-    
+
     if (!player) {
-      throw new FPLError(
-        ErrorCode.PLAYER_NOT_FOUND,
-        `Player with ID ${playerId} not found.`,
-        { playerId }
-      );
+      throw new FPLError(ErrorCode.PLAYER_NOT_FOUND, `Player with ID ${playerId} not found.`, { playerId });
     }
-    
+
     // Find the player's team
     const team = teams.find((t) => t.id === player.team);
     const teamName = team ? team.name : 'Unknown Team';
-    
+
     // Find the player's position
     const elementType = elementTypes.find((et) => et.id === player.element_type);
     const position = elementType ? elementType.singular_name : 'Unknown Position';
-    
+
     // Transform the API response to match our PlayerStats interface
     const playerStats: PlayerStats = {
       id: player.id,
@@ -79,9 +77,9 @@ export async function getPlayerStatsTool(args: PlayerStatsInput): Promise<{ cont
       assists: player.assists,
       cost: player.now_cost / 10, // FPL API returns cost in tenths of millions
       ownership: parseFloat(player.selected_by_percent),
-      form: player.form
+      form: player.form,
     };
-    
+
     return playerStats;
   }, 'getPlayerStatsTool');
 
@@ -103,7 +101,7 @@ export async function getPlayerStatsTool(args: PlayerStatsInput): Promise<{ cont
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/search-players.ts
+++ b/src/tools/search-players.ts
@@ -1,6 +1,6 @@
 /**
  * Search players tool
- * 
+ *
  * This tool allows searching for players by name to find their IDs,
  * eliminating the need for trial and error when looking up player information.
  */
@@ -13,7 +13,9 @@ import { ErrorHandler } from '../utils/error-handler.js';
 /**
  * Search players tool handler
  */
-export async function searchPlayersTool(args: SearchPlayersInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function searchPlayersTool(
+  args: SearchPlayersInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = SearchPlayersInputSchema.safeParse(args);
   if (!validationResult.success) {
@@ -35,17 +37,17 @@ export async function searchPlayersTool(args: SearchPlayersInput): Promise<{ con
 
   const result = await safeExecute(async () => {
     const players = await bootstrapCache.searchPlayers(query);
-    
+
     if (players.length === 0) {
       return {
         message: `No players found matching "${query}". Try a different search term.`,
-        results: []
+        results: [],
       };
     }
-    
+
     return {
       message: `Found ${players.length} player(s) matching "${query}"`,
-      results: players
+      results: players,
     };
   }, 'searchPlayersTool');
 
@@ -67,7 +69,7 @@ export async function searchPlayersTool(args: SearchPlayersInput): Promise<{ con
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/search-teams.ts
+++ b/src/tools/search-teams.ts
@@ -1,6 +1,6 @@
 /**
  * Search teams tool
- * 
+ *
  * This tool allows searching for teams by name to find their IDs,
  * eliminating the need for trial and error when looking up team information.
  */
@@ -13,7 +13,9 @@ import { ErrorHandler } from '../utils/error-handler.js';
 /**
  * Search teams tool handler
  */
-export async function searchTeamsTool(args: SearchTeamsInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function searchTeamsTool(
+  args: SearchTeamsInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = SearchTeamsInputSchema.safeParse(args);
   if (!validationResult.success) {
@@ -35,17 +37,17 @@ export async function searchTeamsTool(args: SearchTeamsInput): Promise<{ content
 
   const result = await safeExecute(async () => {
     const teams = await bootstrapCache.searchTeams(query);
-    
+
     if (teams.length === 0) {
       return {
         message: `No teams found matching "${query}". Try a different search term.`,
-        results: []
+        results: [],
       };
     }
-    
+
     return {
       message: `Found ${teams.length} team(s) matching "${query}"`,
-      results: teams
+      results: teams,
     };
   }, 'searchTeamsTool');
 
@@ -67,7 +69,7 @@ export async function searchTeamsTool(args: SearchTeamsInput): Promise<{ content
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/tools/team-info.ts
+++ b/src/tools/team-info.ts
@@ -1,6 +1,6 @@
 /**
  * Team information tool
- * 
+ *
  * This tool retrieves team details and current squad information
  * for a specified Premier League team.
  */
@@ -14,14 +14,13 @@ import { ErrorHandler, ErrorCode, FPLError } from '../utils/error-handler.js';
 /**
  * Team information tool handler
  */
-export async function getTeamInfoTool(args: TeamInfoInput): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+export async function getTeamInfoTool(
+  args: TeamInfoInput
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   // Validate input
   const validationResult = TeamInfoInputSchema.safeParse(args);
   if (!validationResult.success) {
-    const errorResponse = ErrorHandler.handleValidationError(
-      'Invalid team ID provided',
-      validationResult.error.issues
-    );
+    const errorResponse = ErrorHandler.handleValidationError('Invalid team ID provided', validationResult.error.issues);
     return {
       content: [
         {
@@ -37,10 +36,10 @@ export async function getTeamInfoTool(args: TeamInfoInput): Promise<{ content: A
   const result = await safeExecute(async (): Promise<TeamInfo> => {
     // Initialize FPL client
     const fpl = new FPL();
-    
+
     // Get bootstrap data which includes all teams, players, and element types
     const bootstrapData = await fpl.getBootstrapData();
-    
+
     if (!bootstrapData || !bootstrapData.teams || !bootstrapData.elements || !bootstrapData.element_types) {
       throw new Error('No team data available from FPL API');
     }
@@ -48,27 +47,23 @@ export async function getTeamInfoTool(args: TeamInfoInput): Promise<{ content: A
     const teams = bootstrapData.teams;
     const elements = bootstrapData.elements;
     const elementTypes = bootstrapData.element_types;
-    
+
     // Find the team by ID
     const team = teams.find((t) => t.id === teamId);
-    
+
     if (!team) {
-      throw new FPLError(
-        ErrorCode.TEAM_NOT_FOUND,
-        `Team with ID ${teamId} not found.`,
-        { teamId }
-      );
+      throw new FPLError(ErrorCode.TEAM_NOT_FOUND, `Team with ID ${teamId} not found.`, { teamId });
     }
-    
+
     // Get all players for this team
     const teamPlayers = elements.filter((player) => player.team === teamId);
-    
+
     // Transform players to PlayerStats format
     const players: PlayerStats[] = teamPlayers.map((player) => {
       // Find the player's position
       const elementType = elementTypes.find((et) => et.id === player.element_type);
       const position = elementType ? elementType.singular_name : 'Unknown Position';
-      
+
       return {
         id: player.id,
         name: player.web_name,
@@ -79,19 +74,19 @@ export async function getTeamInfoTool(args: TeamInfoInput): Promise<{ content: A
         assists: player.assists,
         cost: player.now_cost / 10, // FPL API returns cost in tenths of millions
         ownership: parseFloat(player.selected_by_percent),
-        form: player.form
+        form: player.form,
       };
     });
-    
+
     // Create team info response
     const teamInfo: TeamInfo = {
       id: team.id,
       name: team.name,
       shortName: team.short_name,
       code: team.code,
-      players: players
+      players: players,
     };
-    
+
     return teamInfo;
   }, 'teamInfoTool');
 
@@ -113,7 +108,7 @@ export async function getTeamInfoTool(args: TeamInfoInput): Promise<{ content: A
         type: 'text',
         text: JSON.stringify({
           success: true,
-          data: result
+          data: result,
         }),
       },
     ],

--- a/src/types/fpl-types.ts
+++ b/src/types/fpl-types.ts
@@ -11,7 +11,7 @@ export type {
   ManagerSummary,
   ManagerGameweekPicks,
   Gameweek,
-  EventStatus
+  EventStatus,
 } from 'fpl-fetch';
 
 /**
@@ -93,7 +93,7 @@ export interface ErrorResponse {
   error: true;
   message: string;
   code: string;
-  details?: any;
+  details?: unknown;
 }
 
 /**

--- a/src/types/tool-schemas.ts
+++ b/src/types/tool-schemas.ts
@@ -6,48 +6,32 @@ import { z } from 'zod';
 
 // Player statistics tool input
 export const PlayerStatsInputSchema = z.object({
-  playerId: z.number()
-    .int()
-    .min(1, "Player ID must be at least 1")
-    .max(1000, "Player ID must not exceed 1000")
+  playerId: z.number().int().min(1, 'Player ID must be at least 1').max(1000, 'Player ID must not exceed 1000'),
 });
 
 export type PlayerStatsInput = z.infer<typeof PlayerStatsInputSchema>;
 
 // Gameweek fixtures tool input
 export const GameweekFixturesInputSchema = z.object({
-  gameweek: z.number()
-    .int()
-    .min(1, "Gameweek must be at least 1")
-    .max(38, "Gameweek must not exceed 38")
+  gameweek: z.number().int().min(1, 'Gameweek must be at least 1').max(38, 'Gameweek must not exceed 38'),
 });
 
 export type GameweekFixturesInput = z.infer<typeof GameweekFixturesInputSchema>;
 
 // Player comparison tool input
 export const ComparePlayersInputSchema = z.object({
-  playerIds: z.array(
-    z.number()
-      .int()
-      .min(1, "Player ID must be at least 1")
-      .max(1000, "Player ID must not exceed 1000")
-  )
-    .min(2, "At least 2 players required for comparison")
-    .max(10, "Cannot compare more than 10 players at once")
-    .refine(
-      (ids) => new Set(ids).size === ids.length,
-      "Duplicate player IDs are not allowed"
-    )
+  playerIds: z
+    .array(z.number().int().min(1, 'Player ID must be at least 1').max(1000, 'Player ID must not exceed 1000'))
+    .min(2, 'At least 2 players required for comparison')
+    .max(10, 'Cannot compare more than 10 players at once')
+    .refine((ids) => new Set(ids).size === ids.length, 'Duplicate player IDs are not allowed'),
 });
 
 export type ComparePlayersInput = z.infer<typeof ComparePlayersInputSchema>;
 
 // Team information tool input
 export const TeamInfoInputSchema = z.object({
-  teamId: z.number()
-    .int()
-    .min(1, "Team ID must be at least 1")
-    .max(20, "Team ID must not exceed 20")
+  teamId: z.number().int().min(1, 'Team ID must be at least 1').max(20, 'Team ID must not exceed 20'),
 });
 
 export type TeamInfoInput = z.infer<typeof TeamInfoInputSchema>;
@@ -59,33 +43,26 @@ export type CurrentGameweekInput = z.infer<typeof CurrentGameweekInputSchema>;
 
 // Search players tool input
 export const SearchPlayersInputSchema = z.object({
-  query: z.string()
-    .min(1, "Search query must not be empty")
-    .max(100, "Search query must not exceed 100 characters")
+  query: z.string().min(1, 'Search query must not be empty').max(100, 'Search query must not exceed 100 characters'),
 });
 
 export type SearchPlayersInput = z.infer<typeof SearchPlayersInputSchema>;
 
 // Search teams tool input
 export const SearchTeamsInputSchema = z.object({
-  query: z.string()
-    .min(1, "Search query must not be empty")
-    .max(100, "Search query must not exceed 100 characters")
+  query: z.string().min(1, 'Search query must not be empty').max(100, 'Search query must not exceed 100 characters'),
 });
 
 export type SearchTeamsInput = z.infer<typeof SearchTeamsInputSchema>;
 
 // Manager team tool input
 export const ManagerTeamInputSchema = z.object({
-  managerId: z.number()
+  managerId: z
+    .number()
     .int()
-    .min(1, "Manager ID must be at least 1")
-    .max(10000000, "Manager ID must not exceed 10,000,000"),
-  gameweek: z.number()
-    .int()
-    .min(1, "Gameweek must be at least 1")
-    .max(38, "Gameweek must not exceed 38")
-    .optional()
+    .min(1, 'Manager ID must be at least 1')
+    .max(10000000, 'Manager ID must not exceed 10,000,000'),
+  gameweek: z.number().int().min(1, 'Gameweek must be at least 1').max(38, 'Gameweek must not exceed 38').optional(),
 });
 
 export type ManagerTeamInput = z.infer<typeof ManagerTeamInputSchema>;

--- a/src/utils/bootstrap-cache.ts
+++ b/src/utils/bootstrap-cache.ts
@@ -1,6 +1,6 @@
 /**
  * Bootstrap data cache and lookup utilities
- * 
+ *
  * This module provides cached access to FPL bootstrap data and helper functions
  * to search for players and teams by name, avoiding the need for LLMs to guess IDs.
  */
@@ -8,11 +8,41 @@
 import FPL from 'fpl-fetch';
 import { ErrorCode, FPLError } from './error-handler.js';
 
+interface RawPlayer {
+  id: number;
+  web_name: string;
+  first_name: string;
+  second_name: string;
+  team: number;
+  element_type: number;
+  now_cost: number;
+}
+
+interface RawTeam {
+  id: number;
+  name: string;
+  short_name: string;
+  code: number;
+}
+
+interface RawElementType {
+  id: number;
+  singular_name: string;
+}
+
+interface RawEvent {
+  id: number;
+  is_current: boolean;
+  is_next: boolean;
+  deadline_time: string;
+  finished: boolean;
+}
+
 interface BootstrapData {
-  elements: any[];
-  teams: any[];
-  element_types: any[];
-  events: any[];
+  elements: RawPlayer[];
+  teams: RawTeam[];
+  element_types: RawElementType[];
+  events: RawEvent[];
 }
 
 interface PlayerSearchResult {
@@ -42,25 +72,21 @@ class BootstrapCache {
    */
   async getBootstrapData(): Promise<BootstrapData> {
     const now = Date.now();
-    
-    if (this.cache && (now - this.lastFetch) < this.CACHE_TTL) {
+
+    if (this.cache && now - this.lastFetch < this.CACHE_TTL) {
       return this.cache;
     }
 
     const fpl = new FPL();
     const data = await fpl.getBootstrapData();
-    
+
     if (!data || !data.elements || !data.teams || !data.element_types) {
-      throw new FPLError(
-        ErrorCode.NO_DATA_AVAILABLE,
-        'Failed to fetch bootstrap data from FPL API',
-        {}
-      );
+      throw new FPLError(ErrorCode.NO_DATA_AVAILABLE, 'Failed to fetch bootstrap data from FPL API', {});
     }
 
     this.cache = data;
     this.lastFetch = now;
-    
+
     return data;
   }
 
@@ -70,14 +96,14 @@ class BootstrapCache {
   async searchPlayers(query: string): Promise<PlayerSearchResult[]> {
     const data = await this.getBootstrapData();
     const normalizedQuery = query.toLowerCase().trim();
-    
+
     const matches = data.elements
       .filter((player) => {
         const webName = player.web_name.toLowerCase();
         const firstName = player.first_name.toLowerCase();
         const secondName = player.second_name.toLowerCase();
         const fullName = `${firstName} ${secondName}`;
-        
+
         return (
           webName.includes(normalizedQuery) ||
           fullName.includes(normalizedQuery) ||
@@ -88,7 +114,7 @@ class BootstrapCache {
       .map((player) => {
         const team = data.teams.find((t) => t.id === player.team);
         const position = data.element_types.find((et) => et.id === player.element_type);
-        
+
         return {
           id: player.id,
           name: player.web_name,
@@ -100,7 +126,7 @@ class BootstrapCache {
         };
       })
       .slice(0, 10); // Limit to top 10 results
-    
+
     return matches;
   }
 
@@ -110,14 +136,14 @@ class BootstrapCache {
   async getPlayerById(playerId: number): Promise<PlayerSearchResult | null> {
     const data = await this.getBootstrapData();
     const player = data.elements.find((p) => p.id === playerId);
-    
+
     if (!player) {
       return null;
     }
-    
+
     const team = data.teams.find((t) => t.id === player.team);
     const position = data.element_types.find((et) => et.id === player.element_type);
-    
+
     return {
       id: player.id,
       name: player.web_name,
@@ -135,12 +161,12 @@ class BootstrapCache {
   async searchTeams(query: string): Promise<TeamSearchResult[]> {
     const data = await this.getBootstrapData();
     const normalizedQuery = query.toLowerCase().trim();
-    
+
     const matches = data.teams
       .filter((team) => {
         const name = team.name.toLowerCase();
         const shortName = team.short_name.toLowerCase();
-        
+
         return name.includes(normalizedQuery) || shortName.includes(normalizedQuery);
       })
       .map((team) => ({
@@ -149,7 +175,7 @@ class BootstrapCache {
         shortName: team.short_name,
         code: team.code,
       }));
-    
+
     return matches;
   }
 
@@ -159,11 +185,11 @@ class BootstrapCache {
   async getTeamById(teamId: number): Promise<TeamSearchResult | null> {
     const data = await this.getBootstrapData();
     const team = data.teams.find((t) => t.id === teamId);
-    
+
     if (!team) {
       return null;
     }
-    
+
     return {
       id: team.id,
       name: team.name,

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -11,29 +11,29 @@ export enum ErrorCode {
   INVALID_PLAYER_ID = 'INVALID_PLAYER_ID',
   INVALID_GAMEWEEK = 'INVALID_GAMEWEEK',
   INVALID_TEAM_ID = 'INVALID_TEAM_ID',
-  
+
   // API errors
   API_UNAVAILABLE = 'API_UNAVAILABLE',
   API_TIMEOUT = 'API_TIMEOUT',
   API_RATE_LIMITED = 'API_RATE_LIMITED',
   API_INVALID_RESPONSE = 'API_INVALID_RESPONSE',
-  
+
   // Data errors
   PLAYER_NOT_FOUND = 'PLAYER_NOT_FOUND',
   TEAM_NOT_FOUND = 'TEAM_NOT_FOUND',
   GAMEWEEK_NOT_FOUND = 'GAMEWEEK_NOT_FOUND',
   NO_DATA_AVAILABLE = 'NO_DATA_AVAILABLE',
-  
+
   // System errors
   INTERNAL_ERROR = 'INTERNAL_ERROR',
-  NETWORK_ERROR = 'NETWORK_ERROR'
+  NETWORK_ERROR = 'NETWORK_ERROR',
 }
 
 export class FPLError extends Error {
   constructor(
     public code: ErrorCode,
     message: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message);
     this.name = 'FPLError';
@@ -47,73 +47,66 @@ export class ErrorHandler {
   /**
    * Creates a standardized error response
    */
-  static createErrorResponse(
-    code: ErrorCode,
-    message: string,
-    details?: any
-  ): ErrorResponse {
+  static createErrorResponse(code: ErrorCode, message: string, details?: unknown): ErrorResponse {
     return {
       error: true,
       message,
       code,
-      details
+      details,
     };
   }
 
   /**
    * Handles validation errors
    */
-  static handleValidationError(message: string, details?: any): ErrorResponse {
+  static handleValidationError(message: string, details?: unknown): ErrorResponse {
     return this.createErrorResponse(ErrorCode.VALIDATION_ERROR, message, details);
   }
 
   /**
    * Handles API-related errors
    */
-  static handleApiError(error: any): ErrorResponse {
-    if (error?.response?.status === 429) {
+  static handleApiError(error: unknown): ErrorResponse {
+    const err = error as { response?: { status?: number }; code?: string; message?: string };
+    if (err?.response?.status === 429) {
       return this.createErrorResponse(
         ErrorCode.API_RATE_LIMITED,
         'FPL API rate limit exceeded. Please try again later.',
-        { status: error.response.status }
+        { status: err.response.status }
       );
     }
 
-    if (error?.code === 'ENOTFOUND' || error?.code === 'ECONNREFUSED') {
+    if (err?.code === 'ENOTFOUND' || err?.code === 'ECONNREFUSED') {
       return this.createErrorResponse(
         ErrorCode.NETWORK_ERROR,
         'Unable to connect to FPL API. Please check your internet connection.',
-        { code: error.code }
+        { code: err.code }
       );
     }
 
-    if (error?.code === 'ETIMEDOUT') {
-      return this.createErrorResponse(
-        ErrorCode.API_TIMEOUT,
-        'FPL API request timed out. Please try again.',
-        { code: error.code }
-      );
+    if (err?.code === 'ETIMEDOUT') {
+      return this.createErrorResponse(ErrorCode.API_TIMEOUT, 'FPL API request timed out. Please try again.', {
+        code: err.code,
+      });
     }
 
-    if (error?.response?.status >= 500) {
+    if (err?.response?.status !== undefined && err.response.status >= 500) {
       return this.createErrorResponse(
         ErrorCode.API_UNAVAILABLE,
         'FPL API is currently unavailable. Please try again later.',
-        { status: error.response.status }
+        { status: err.response.status }
       );
     }
 
-    return this.createErrorResponse(
-      ErrorCode.API_INVALID_RESPONSE,
-      'Received invalid response from FPL API.',
-      { error: error.message }
-    );
+    return this.createErrorResponse(ErrorCode.API_INVALID_RESPONSE, 'Received invalid response from FPL API.', {
+      error: err?.message,
+    });
   }
 
   /**
    * Handles data-related errors
    */
-  static handleDataError(code: ErrorCode, message: string, details?: any): ErrorResponse {
+  static handleDataError(code: ErrorCode, message: string, details?: unknown): ErrorResponse {
     return this.createErrorResponse(code, message, details);
   }
 
@@ -121,22 +114,14 @@ export class ErrorHandler {
    * Handles player-specific errors
    */
   static handlePlayerError(playerId: number): ErrorResponse {
-    return this.createErrorResponse(
-      ErrorCode.PLAYER_NOT_FOUND,
-      `Player with ID ${playerId} not found.`,
-      { playerId }
-    );
+    return this.createErrorResponse(ErrorCode.PLAYER_NOT_FOUND, `Player with ID ${playerId} not found.`, { playerId });
   }
 
   /**
    * Handles team-specific errors
    */
   static handleTeamError(teamId: number): ErrorResponse {
-    return this.createErrorResponse(
-      ErrorCode.TEAM_NOT_FOUND,
-      `Team with ID ${teamId} not found.`,
-      { teamId }
-    );
+    return this.createErrorResponse(ErrorCode.TEAM_NOT_FOUND, `Team with ID ${teamId} not found.`, { teamId });
   }
 
   /**
@@ -153,13 +138,13 @@ export class ErrorHandler {
   /**
    * Handles unexpected errors
    */
-  static handleUnexpectedError(error: any): ErrorResponse {
+  static handleUnexpectedError(error: unknown): ErrorResponse {
     logger.error('Unexpected error', { error });
-    
+    const err = error as { message?: string; stack?: string };
     return this.createErrorResponse(
       ErrorCode.INTERNAL_ERROR,
       'An unexpected error occurred. Please try again.',
-      process.env.NODE_ENV === 'development' ? { error: error.message, stack: error.stack } : undefined
+      process.env.NODE_ENV === 'development' ? { error: err?.message, stack: err?.stack } : undefined
     );
   }
 
@@ -167,12 +152,8 @@ export class ErrorHandler {
    * Determines if an error is retryable
    */
   static isRetryableError(error: ErrorResponse): boolean {
-    const retryableCodes = [
-      ErrorCode.API_TIMEOUT,
-      ErrorCode.NETWORK_ERROR,
-      ErrorCode.API_UNAVAILABLE
-    ];
-    
+    const retryableCodes = [ErrorCode.API_TIMEOUT, ErrorCode.NETWORK_ERROR, ErrorCode.API_UNAVAILABLE];
+
     return retryableCodes.includes(error.code as ErrorCode);
   }
 }
@@ -180,17 +161,14 @@ export class ErrorHandler {
 /**
  * Utility function to safely execute async operations with error handling
  */
-export async function safeExecute<T>(
-  operation: () => Promise<T>,
-  errorContext?: string
-): Promise<T | ErrorResponse> {
+export async function safeExecute<T>(operation: () => Promise<T>, errorContext?: string): Promise<T | ErrorResponse> {
   try {
     return await operation();
   } catch (error) {
     if (error instanceof FPLError) {
       return ErrorHandler.createErrorResponse(error.code, error.message, error.details);
     }
-    
+
     logger.error(`Error in ${errorContext || 'operation'}`, { error });
     return ErrorHandler.handleUnexpectedError(error);
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -13,18 +13,18 @@ const customFormat = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
   winston.format.errors({ stack: true }),
   winston.format.printf(({ level, message, timestamp, stack, ...metadata }) => {
-    let msg = `${timestamp} [${level.toUpperCase()}]: ${message}`;
-    
+    let msg = `${String(timestamp)} [${(level as string).toUpperCase()}]: ${String(message)}`;
+
     // Add metadata if present
     if (Object.keys(metadata).length > 0) {
       msg += ` ${JSON.stringify(metadata)}`;
     }
-    
+
     // Add stack trace if present
     if (stack) {
-      msg += `\n${stack}`;
+      msg += `\n${typeof stack === 'string' ? stack : JSON.stringify(stack)}`;
     }
-    
+
     return msg;
   })
 );
@@ -45,10 +45,7 @@ export const logger = winston.createLogger({
 
 // Add colorization in development mode
 if (nodeEnv === 'development') {
-  logger.format = winston.format.combine(
-    winston.format.colorize(),
-    customFormat
-  );
+  logger.format = winston.format.combine(winston.format.colorize(), customFormat);
 }
 
 export default logger;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -21,25 +21,25 @@ export function validateInput<T>(
         success: false,
         error: {
           error: true,
-          message: "Invalid input parameters",
-          code: "VALIDATION_ERROR",
-          details: error.issues.map(err => ({
+          message: 'Invalid input parameters',
+          code: 'VALIDATION_ERROR',
+          details: error.issues.map((err) => ({
             path: err.path.join('.'),
             message: err.message,
-            code: err.code
-          }))
-        }
+            code: err.code,
+          })),
+        },
       };
     }
-    
+
     return {
       success: false,
       error: {
         error: true,
-        message: "Unexpected validation error",
-        code: "VALIDATION_ERROR",
-        details: error
-      }
+        message: 'Unexpected validation error',
+        code: 'VALIDATION_ERROR',
+        details: error,
+      },
     };
   }
 }
@@ -76,14 +76,14 @@ export const ValidationPatterns = {
     if (!Array.isArray(ids) || ids.length < 2 || ids.length > 10) {
       return false;
     }
-    
+
     // Check for duplicates
     const uniqueIds = new Set(ids);
     if (uniqueIds.size !== ids.length) {
       return false;
     }
-    
+
     // Check each ID is valid
-    return ids.every(id => ValidationPatterns.isValidPlayerId(id));
-  }
+    return ids.every((id) => ValidationPatterns.isValidPlayerId(id));
+  },
 };


### PR DESCRIPTION
Introduces Oxlint and Oxfmt as the project's linting and formatting stack, with oxlint-tsgolint for type-aware rules. All three are pinned to exact versions given Oxlint's semver policy of treating new lint rules as non-breaking, and oxlint-tsgolint's explicit exclusion from semver guarantees.

Four scripts are added to package.json: lint, lint:fix, fmt, fmt:check. Two new CI jobs (lint, format-check) are added to ci.yml, running in parallel with the existing build job on every push and pull request.

Resolves all warnings surfaced by the initial lint run.